### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -14,3 +14,4 @@ Dependency | Sources | Version | Mismatched versions
 [corinnekrych/corinnejs3](https://github.com/corinnekrych/corinnejs3.git) |  | []() | 
 [corinnekrych/corinnejs4](https://github.com/corinnekrych/corinnejs4.git) |  | []() | 
 [corinnekrych/healthy-katydid](https://github.com/corinnekrych/healthy-katydid.git) |  | []() | 
+[corinnekrych/rare-peacock](https://github.com/corinnekrych/rare-peacock.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -14,4 +14,4 @@ Dependency | Sources | Version | Mismatched versions
 [corinnekrych/corinnejs3](https://github.com/corinnekrych/corinnejs3.git) |  | []() | 
 [corinnekrych/corinnejs4](https://github.com/corinnekrych/corinnejs4.git) |  | []() | 
 [corinnekrych/healthy-katydid](https://github.com/corinnekrych/healthy-katydid.git) |  | []() | 
-[corinnekrych/modern-swan](https://github.com/corinnekrych/modern-swan.git) |  | []() | 
+[corinnekrych/driving-raccoon](https://github.com/corinnekrych/driving-raccoon.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -14,4 +14,4 @@ Dependency | Sources | Version | Mismatched versions
 [corinnekrych/corinnejs3](https://github.com/corinnekrych/corinnejs3.git) |  | []() | 
 [corinnekrych/corinnejs4](https://github.com/corinnekrych/corinnejs4.git) |  | []() | 
 [corinnekrych/healthy-katydid](https://github.com/corinnekrych/healthy-katydid.git) |  | []() | 
-[corinnekrych/rare-peacock](https://github.com/corinnekrych/rare-peacock.git) |  | []() | 
+[corinnekrych/modern-swan](https://github.com/corinnekrych/modern-swan.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -73,7 +73,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: corinnekrych
-  repo: modern-swan
-  url: https://github.com/corinnekrych/modern-swan.git
+  repo: driving-raccoon
+  url: https://github.com/corinnekrych/driving-raccoon.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -71,3 +71,9 @@ dependencies:
   url: https://github.com/corinnekrych/healthy-katydid.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: corinnekrych
+  repo: rare-peacock
+  url: https://github.com/corinnekrych/rare-peacock.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -73,7 +73,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: corinnekrych
-  repo: rare-peacock
-  url: https://github.com/corinnekrych/rare-peacock.git
+  repo: modern-swan
+  url: https://github.com/corinnekrych/modern-swan.git
   version: ""
   versionURL: ""

--- a/repositories/templates/corinnekrych-driving-raccoon-sr.yaml
+++ b/repositories/templates/corinnekrych-driving-raccoon-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: corinnekrych
+    provider: github
+    repository: driving-raccoon
+  name: corinnekrych-driving-raccoon
+spec:
+  description: Imported application for corinnekrych/driving-raccoon
+  httpCloneURL: https://github.com/corinnekrych/driving-raccoon.git
+  org: corinnekrych
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: driving-raccoon
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/corinnekrych/driving-raccoon.git

--- a/repositories/templates/corinnekrych-modern-swan-sr.yaml
+++ b/repositories/templates/corinnekrych-modern-swan-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: corinnekrych
+    provider: github
+    repository: modern-swan
+  name: corinnekrych-modern-swan
+spec:
+  description: Imported application for corinnekrych/modern-swan
+  httpCloneURL: https://github.com/corinnekrych/modern-swan.git
+  org: corinnekrych
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: modern-swan
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/corinnekrych/modern-swan.git

--- a/repositories/templates/corinnekrych-rare-peacock-sr.yaml
+++ b/repositories/templates/corinnekrych-rare-peacock-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: corinnekrych
+    provider: github
+    repository: rare-peacock
+  name: corinnekrych-rare-peacock
+spec:
+  description: Imported application for corinnekrych/rare-peacock
+  httpCloneURL: https://github.com/corinnekrych/rare-peacock.git
+  org: corinnekrych
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: rare-peacock
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/corinnekrych/rare-peacock.git


### PR DESCRIPTION
Update [corinnekrych/driving-raccoon](https://github.com/corinnekrych/driving-raccoon.git) 

Command run was `jx create quickstart -b -o /var/folders/8c/f4kdj2fx5wd001vl2bpk4sc00000gn/T/e2e-751037168 --org corinnekrych -p driving-raccoon -f golang-http`
<hr />

Update [corinnekrych/modern-swan](https://github.com/corinnekrych/modern-swan.git) 

Command run was `jx create quickstart -b -o /var/folders/8c/f4kdj2fx5wd001vl2bpk4sc00000gn/T/e2e-249328789 --org corinnekrych -p modern-swan -f golang-http`
<hr />

Update [corinnekrych/rare-peacock](https://github.com/corinnekrych/rare-peacock.git) 

Command run was `jx create quickstart -b -o /var/folders/8c/f4kdj2fx5wd001vl2bpk4sc00000gn/T/e2e-249328789 --org corinnekrych -p rare-peacock -f golang-http`